### PR TITLE
Add systemd socket activation for on-demand container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,4 @@ EXPOSE 5000
 
 # Entrypoint delegates to server.py; pass --sd-activate for socket activation
 ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["python", "server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the server code
-COPY server.py .
+# Copy the server code and entrypoint
+COPY server.py docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
 
 # Set environment variables
 ENV DATA_DIR=/data
@@ -29,5 +30,5 @@ RUN mkdir -p /data
 # Expose the port
 EXPOSE 5000
 
-# Run the server using python directly
-CMD ["python", "server.py"]
+# Entrypoint delegates to server.py; pass --sd-activate for socket activation
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,35 @@ docker run --rm -p 5000:5000 -v "$(pwd)/piper-data:/data" my-piper-tts
 
 The published image already contains `espeak-ng`, `libsndfile1`, and `ffmpeg` for MP3 conversion.
 
+### systemd socket activation (Podman Quadlet)
+
+Socket activation lets systemd own the listening port and start the container on demand — zero resource usage when idle, instant recovery on crash, and no manual `docker run` needed.
+
+1. Prepare the voice data directory:
+   ```bash
+   mkdir -p ~/.local/share/piper-tts/
+   ```
+
+2. Copy the unit files:
+   ```bash
+   cp systemd/piper-tts.socket   ~/.config/systemd/user/
+   cp systemd/piper-tts.container ~/.config/containers/systemd/
+   ```
+
+3. Reload and enable:
+   ```bash
+   systemctl --user daemon-reload
+   systemctl --user enable --now piper-tts.socket
+   ```
+
+The container starts automatically on the first request to port 5000. Verify with:
+```bash
+curl -s -o /dev/null -w '%{http_code}' \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"piper","voice":"en_US-lessac-medium","input":"Hello"}' \
+  http://localhost:5000/v1/audio/speech
+```
+
 ---
 
 ## API Overview

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# If the first argument starts with '-' or is a known server flag,
+# prepend the python server command.
+if [ "${1#-}" != "$1" ] || [ "$1" = "--sd-activate" ]; then
+    set -- python server.py "$@"
+fi
+
+exec "$@"

--- a/server.py
+++ b/server.py
@@ -1,5 +1,8 @@
+import argparse
+import asyncio
 import os
 import logging
+import socket
 import subprocess
 import requests
 import uvicorn
@@ -377,5 +380,48 @@ async def generate_speech(request: OpenAISpeechRequest):
         media_type=media_type,
     )
 
-if __name__ == "__main__":
+class _ActivatedSocket(socket.socket):
+    """Socket that skips listen() — already done by systemd."""
+
+    def listen(self, __backlog: int = 0) -> None:  # noqa: D102
+        pass
+
+
+def _run_sd_activated() -> None:
+    """Start uvicorn using a systemd socket-activated file descriptor.
+
+    systemd passes the listening socket as fd 3.  uvicorn 0.27 hardcodes
+    AF_UNIX in socket.fromfd() for --fd, and asyncio calls sock.listen()
+    which fails on an already-listening socket in rootless containers.
+    We work around both issues with a custom socket subclass.
+    """
+    sock = _ActivatedSocket(
+        fileno=3,
+        family=socket.AF_INET6,
+        type=socket.SOCK_STREAM,
+    )
+    sock.setblocking(False)
+
+    config = uvicorn.Config("server:app")
+    server = uvicorn.Server(config)
+    asyncio.run(server.serve(sockets=[sock]))
+
+
+def _run_http_server() -> None:
+    """Start uvicorn binding directly to host:port."""
     uvicorn.run(app, host="0.0.0.0", port=PORT)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Piper OpenAI TTS HTTP Server")
+    parser.add_argument(
+        "--sd-activate",
+        action="store_true",
+        help="Use systemd socket activation (fd 3) instead of binding a port.",
+    )
+    args = parser.parse_args()
+
+    if args.sd_activate:
+        _run_sd_activated()
+    else:
+        _run_http_server()

--- a/systemd/piper-tts.container
+++ b/systemd/piper-tts.container
@@ -1,0 +1,21 @@
+# Podman Quadlet unit for Piper OpenAI-TTS with systemd socket activation.
+# Author: Piotr Minkina <piotrminkina@users.noreply.github.com>
+#
+# Deploy to: ~/.config/containers/systemd/piper-tts.container
+# Reload:    systemctl --user daemon-reload
+# Start:     systemctl --user start piper-tts.socket
+
+[Unit]
+Description=Piper OpenAI-TTS Container
+Requires=piper-tts.socket
+After=piper-tts.socket
+
+[Container]
+Image=docker.io/kamilkrawiec/piper-openai-tts:latest
+Exec=--sd-activate
+Network=pasta
+Volume=%h/.local/share/piper-tts/:/data/:rw
+Annotation=run.oci.keep_original_groups=1
+
+[Install]
+WantedBy=default.target

--- a/systemd/piper-tts.socket
+++ b/systemd/piper-tts.socket
@@ -1,0 +1,16 @@
+# systemd socket unit for Piper TTS on-demand activation.
+# Author: Piotr Minkina <piotrminkina@users.noreply.github.com>
+#
+# Deploy to: ~/.config/systemd/user/piper-tts.socket
+# Enable:    systemctl --user enable --now piper-tts.socket
+
+[Unit]
+Description=Piper TTS Socket
+
+[Socket]
+# Passed as fd 3 (AF_INET6 dual-stack) to uvicorn via --sd-activate
+ListenStream=[::]:5000
+BindIPv6Only=default
+
+[Install]
+WantedBy=sockets.target

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -78,3 +78,45 @@ def test_download_voice_if_missing_rejects_bad_name(monkeypatch, tmp_path):
 
     # Voice name that does not match the expected pattern should be rejected
     assert server.download_voice_if_missing("badvoice") is False
+
+
+# --- Startup mode smoke tests ---
+
+
+def test_default_startup_calls_http_server(monkeypatch):
+    """No-arg startup must invoke _run_http_server (normal bind mode)."""
+    called = {}
+
+    monkeypatch.setattr(server, "_run_http_server", lambda: called.update(http=True))
+    monkeypatch.setattr(server, "_run_sd_activated", lambda: called.update(sd=True))
+
+    args = server.argparse.Namespace(sd_activate=False)
+    monkeypatch.setattr(server.argparse.ArgumentParser, "parse_args", lambda self: args)
+
+    # Re-execute the __main__ guard logic
+    if args.sd_activate:
+        server._run_sd_activated()
+    else:
+        server._run_http_server()
+
+    assert "http" in called
+    assert "sd" not in called
+
+
+def test_sd_activate_flag_calls_sd_activated(monkeypatch):
+    """--sd-activate must invoke _run_sd_activated (socket activation mode)."""
+    called = {}
+
+    monkeypatch.setattr(server, "_run_http_server", lambda: called.update(http=True))
+    monkeypatch.setattr(server, "_run_sd_activated", lambda: called.update(sd=True))
+
+    args = server.argparse.Namespace(sd_activate=True)
+    monkeypatch.setattr(server.argparse.ArgumentParser, "parse_args", lambda self: args)
+
+    if args.sd_activate:
+        server._run_sd_activated()
+    else:
+        server._run_http_server()
+
+    assert "sd" in called
+    assert "http" not in called


### PR DESCRIPTION
## Summary

- **`server.py --sd-activate`** — new flag that accepts a pre-listening socket on fd 3 from systemd instead of binding a port directly. Works around uvicorn 0.27's `AF_UNIX` hardcoding and redundant `listen()` call that fails in rootless containers.
- **`systemd/piper-tts.socket`** + **`systemd/piper-tts.container`** — Podman Quadlet unit files for rootless deployment with automatic lifecycle management.
- **`docker-entrypoint.sh`** — standard Docker entrypoint pattern: flags (e.g. `--sd-activate`) get prepended with `python server.py`, anything else runs as a command in the container.
- **`Dockerfile`** — switched from bare `CMD` to `ENTRYPOINT` + `CMD` to support both modes.
- **`README.md`** — deployment instructions for systemd socket activation.

## Why

Socket activation brings significant operational benefits for self-hosted TTS:

1. **Zero idle resource usage** — the container only starts when the first request hits the port; no CPU/RAM consumed when TTS is not in use.
2. **Automatic crash recovery** — systemd restarts the service on failure without external health checks or supervisors.
3. **Rootless security** — Podman Quadlet runs in user space, no `docker.sock` or root privileges needed.
4. **Native OS integration** — `journalctl --user -u piper-tts` for logs, `systemctl --user` for lifecycle management.
5. **Declarative config** — `.container` + `.socket` files replace long `docker run` commands with flags.

## Test plan

- [x] `docker build` succeeds
- [x] Standard mode: `docker run ... piper-tts-test` → HTTP 200, valid WAV audio
- [x] Socket activation: `systemd-socket-activate -l 15001 podman run ... --sd-activate` → HTTP 200, valid WAV audio via fd 3
- [ ] Verify existing unit tests still pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)